### PR TITLE
Addition of GetFileInfos operation

### DIFF
--- a/message-xml-xsd/src/main/resources/examples/data/GetFileInfosResults.xml
+++ b/message-xml-xsd/src/main/resources/examples/data/GetFileInfosResults.xml
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  #%L
+  Bitmagasin protokol
+
+  $Id$
+  $HeadURL$
+  %%
+  Copyright (C) 2010 The State and University Library, The Royal Library and The State Archives, Denmark
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 2.1 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+
+  You should have received a copy of the GNU General Lesser Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  #L%
+  -->
+
+<bro:GetFileInfosResults version="31" minVersion="31" xmlns:bro='http://bitrepository.org/BitRepositoryData.xsd'
+xmlns="http://bitrepository.org/BitRepositoryElements.xsd">
+  <CollectionID>MySla</CollectionID>
+  <PillarID>MyPillar</PillarID>
+  <FileInfosDataItem>
+    <FileID>MyFile1</FileID>
+    <FileSize>1</FileSize>
+    <LastModificationTime>2019-05-20T11:11:11.111+02:00</LastModificationTime>
+    <ChecksumValue>ABCDABCD</ChecksumValue>
+    <CalculationTimestamp>2019-05-20T11:11:11.111+02:00</CalculationTimestamp>
+  </FileInfosDataItem>
+  <FileInfosDataItem>
+    <FileID>MyFile2</FileID>
+    <FileSize>2</FileSize>
+    <LastModificationTime>1970-01-01T01:00:00.000+00:00</LastModificationTime>
+    <ChecksumValue>1234567890ABCDEF</ChecksumValue>
+    <CalculationTimestamp>1970-01-01T01:00:00.000+00:00</CalculationTimestamp>
+  </FileInfosDataItem>
+</bro:GetFileInfosResults>

--- a/message-xml-xsd/src/main/resources/examples/messages/GetFileInfosFinalResponse.xml
+++ b/message-xml-xsd/src/main/resources/examples/messages/GetFileInfosFinalResponse.xml
@@ -45,16 +45,12 @@
     <ChecksumSalt>5A17</ChecksumSalt>
   </ChecksumRequestForExistingFile>
   <ResultingFileInfos>
-    <FileInfosData>
-      <FileInfosDataItems>
-        <FileInfosDataItem>
-          <FileID>MyDataID1</FileID>
-          <FileSize>1</FileSize>
-          <LastModificationTime>2019-05-20T11:11:11.111+02:00</LastModificationTime>
-          <ChecksumValue>ABCDABCD</ChecksumValue>
-          <CalculationTimestamp>2019-05-20T11:11:11.111+02:00</CalculationTimestamp>
-        </FileInfosDataItem>
-      </FileInfosDataItems>
-    </FileInfosData>
+    <FileInfosDataItem>
+      <FileID>MyDataID1</FileID>
+      <FileSize>1</FileSize>
+      <LastModificationTime>2019-05-20T11:11:11.111+02:00</LastModificationTime>
+      <ChecksumValue>ABCDABCD</ChecksumValue>
+      <CalculationTimestamp>2019-05-20T11:11:11.111+02:00</CalculationTimestamp>
+    </FileInfosDataItem>
   </ResultingFileInfos>
 </bro:GetFileInfosFinalResponse>

--- a/message-xml-xsd/src/main/resources/examples/messages/GetFileInfosFinalResponse.xml
+++ b/message-xml-xsd/src/main/resources/examples/messages/GetFileInfosFinalResponse.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Bitmagasin protokol
+
+  $Id$
+  $HeadURL$
+  %%
+  Copyright (C) 2010 The State and University Library, The Royal Library and The State Archives, Denmark
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 2.1 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+
+  You should have received a copy of the GNU General Lesser Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  #L%
+  -->
+
+<bro:GetFileInfosFinalResponse version="29" minVersion="24"
+                             xmlns:bro='http://bitrepository.org/BitRepositoryMessages.xsd'
+                             xmlns="http://bitrepository.org/BitRepositoryElements.xsd">
+  <CorrelationID>12345</CorrelationID>
+  <CollectionID>MySla</CollectionID>
+  <Destination>topic://clientTopic</Destination>
+  <ReplyTo>queue://pillarQueue</ReplyTo>
+  <From>MyPillar</From>
+  <ResponseInfo>
+    <ResponseCode>OPERATION_COMPLETED</ResponseCode>
+    <ResponseText>successfull completion</ResponseText>
+  </ResponseInfo>
+  <PillarID>MyPillar</PillarID>
+  <FileIDs>
+    <FileID>MyDataID1</FileID>
+  </FileIDs>
+  <ChecksumRequestForExistingFile>
+    <ChecksumType>HMAC_SHA384</ChecksumType>
+    <ChecksumSalt>5A17</ChecksumSalt>
+  </ChecksumRequestForExistingFile>
+  <ResultingFileInfos>
+    <FileInfosData>
+      <FileInfosDataItems>
+        <FileInfosDataItem>
+          <FileID>MyDataID1</FileID>
+          <FileSize>1</FileSize>
+          <LastModificationTime>2019-05-20T11:11:11.111+02:00</LastModificationTime>
+          <ChecksumValue>ABCDABCD</ChecksumValue>
+          <CalculationTimestamp>2019-05-20T11:11:11.111+02:00</CalculationTimestamp>
+        </FileInfosDataItem>
+      </FileInfosDataItems>
+    </FileInfosData>
+  </ResultingFileInfos>
+</bro:GetFileInfosFinalResponse>

--- a/message-xml-xsd/src/main/resources/examples/messages/GetFileInfosProgressResponse.xml
+++ b/message-xml-xsd/src/main/resources/examples/messages/GetFileInfosProgressResponse.xml
@@ -40,5 +40,9 @@ xmlns="http://bitrepository.org/BitRepositoryElements.xsd">
   <FileIDs>
     <FileID>MyDataID1</FileID>
   </FileIDs>
+  <ChecksumRequestForExistingFile>
+    <ChecksumType>HMAC_SHA384</ChecksumType>
+    <ChecksumSalt>5A17</ChecksumSalt>
+  </ChecksumRequestForExistingFile>
   <ResultAddress>http://myServer/myPlace/Myfile</ResultAddress>
 </bro:GetFileInfosProgressResponse>

--- a/message-xml-xsd/src/main/resources/examples/messages/GetFileInfosProgressResponse.xml
+++ b/message-xml-xsd/src/main/resources/examples/messages/GetFileInfosProgressResponse.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  #%L
+  Bitmagasin protokol
+
+  $Id$
+  $HeadURL$
+  %%
+  Copyright (C) 2010 The State and University Library, The Royal Library and The State Archives, Denmark
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 2.1 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+
+  You should have received a copy of the GNU General Lesser Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  #L%
+  -->
+
+<bro:GetFileInfosProgressResponse version="31" minVersion="31"
+xmlns:bro='http://bitrepository.org/BitRepositoryMessages.xsd'
+xmlns="http://bitrepository.org/BitRepositoryElements.xsd">
+  <CorrelationID>12345</CorrelationID>
+  <CollectionID>MySla</CollectionID>
+  <Destination>topic://clientTopic</Destination>
+  <ReplyTo>queue://pillarQueue</ReplyTo>
+  <From>MyPillar</From>
+  <ResponseInfo>
+    <ResponseCode>OPERATION_ACCEPTED_PROGRESS</ResponseCode>
+    <ResponseText>Message request has been received and is expected to be met successfully</ResponseText>
+  </ResponseInfo>
+  <PillarID>MyPillar</PillarID>
+  <FileIDs>
+    <FileID>MyDataID1</FileID>
+  </FileIDs>
+  <ResultAddress>http://myServer/myPlace/Myfile</ResultAddress>
+</bro:GetFileInfosProgressResponse>

--- a/message-xml-xsd/src/main/resources/examples/messages/GetFileInfosRequest.xml
+++ b/message-xml-xsd/src/main/resources/examples/messages/GetFileInfosRequest.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  #%L
+  Bitmagasin protokol
+
+  $Id$
+  $HeadURL$
+  %%
+  Copyright (C) 2010 The State and University Library, The Royal Library and The State Archives, Denmark
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 2.1 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+
+  You should have received a copy of the GNU General Lesser Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  #L%
+  -->
+
+<bro:GetFileInfosRequest version="31" minVersion="31"
+xmlns:bro='http://bitrepository.org/BitRepositoryMessages.xsd'
+xmlns="http://bitrepository.org/BitRepositoryElements.xsd">
+  <CorrelationID>12345</CorrelationID>
+  <CollectionID>MySla</CollectionID>
+  <Destination>queue://pillarQueue</Destination>
+  <ReplyTo>topic://clientTopic</ReplyTo>
+  <From>ClientPillar</From>
+  <AuditTrailInformation>User: Name, Institution: Place</AuditTrailInformation>
+  <PillarID>MyPillar</PillarID>
+  <FileIDs>
+    <FileID>MyDataID1</FileID>
+  </FileIDs>
+  <ChecksumRequestForExistingFile>
+    <ChecksumType>HMAC_SHA384</ChecksumType>
+    <ChecksumSalt>5A17</ChecksumSalt>
+  </ChecksumRequestForExistingFile>
+  <GetFileSize>true</GetFileSize>
+  <MinFileTimestamp>1970-01-01T01:00:00.000+00:00</MinFileTimestamp>
+  <MaxFileTimestamp>2019-05-20T11:37:00.000+02:00</MaxFileTimestamp>
+  <MinChecksumTimestamp>1970-01-01T01:00:00.000+00:00</MinChecksumTimestamp>
+  <MaxChecksumTimestamp>2019-05-20T11:37:00.000+02:00</MaxChecksumTimestamp>
+  <MaxNumberOfResults>1</MaxNumberOfResults>
+  <ResultAddress>http://myServer/myPlace/Myfile</ResultAddress>
+</bro:GetFileInfosRequest>

--- a/message-xml-xsd/src/main/resources/examples/messages/IdentifyPillarsForGetFileInfosRequest.xml
+++ b/message-xml-xsd/src/main/resources/examples/messages/IdentifyPillarsForGetFileInfosRequest.xml
@@ -36,4 +36,8 @@ xmlns="http://bitrepository.org/BitRepositoryElements.xsd">
   <FileIDs>
     <FileID>MyDataID1</FileID>
   </FileIDs>
+  <ChecksumRequestForExistingFile>
+    <ChecksumType>HMAC_SHA384</ChecksumType>
+    <ChecksumSalt>5A17</ChecksumSalt>
+  </ChecksumRequestForExistingFile>
 </bro:IdentifyPillarsForGetFileInfosRequest>

--- a/message-xml-xsd/src/main/resources/examples/messages/IdentifyPillarsForGetFileInfosRequest.xml
+++ b/message-xml-xsd/src/main/resources/examples/messages/IdentifyPillarsForGetFileInfosRequest.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  #%L
+  Bitmagasin protokol
+
+  $Id$
+  $HeadURL$
+  %%
+  Copyright (C) 2010 The State and University Library, The Royal Library and The State Archives, Denmark
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 2.1 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+
+  You should have received a copy of the GNU General Lesser Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  #L%
+  -->
+
+<bro:IdentifyPillarsForGetFileInfosRequest version="31" minVersion="31"
+xmlns:bro='http://bitrepository.org/BitRepositoryMessages.xsd'
+xmlns="http://bitrepository.org/BitRepositoryElements.xsd">
+  <CorrelationID>12345</CorrelationID>
+  <CollectionID>MySla</CollectionID>
+  <Destination>topic://collectionTopic</Destination>
+  <ReplyTo>topic://clientTopic</ReplyTo>
+  <From>ClientPillar</From>
+  <AuditTrailInformation>User: Name, Institution: Place</AuditTrailInformation>
+  <FileIDs>
+    <FileID>MyDataID1</FileID>
+  </FileIDs>
+</bro:IdentifyPillarsForGetFileInfosRequest>

--- a/message-xml-xsd/src/main/resources/examples/messages/IdentifyPillarsForGetFileInfosResponse.xml
+++ b/message-xml-xsd/src/main/resources/examples/messages/IdentifyPillarsForGetFileInfosResponse.xml
@@ -37,6 +37,14 @@
     <ResponseText>Ready to deliver fileIDS.</ResponseText>
   </ResponseInfo>
   <PillarID>MyPillar</PillarID>
+  <ChecksumRequestForExistingFile>
+    <ChecksumType>HMAC_SHA384</ChecksumType>
+    <ChecksumSalt>5A17</ChecksumSalt>
+  </ChecksumRequestForExistingFile>
+  <PillarChecksumSpec>
+    <ChecksumType>HMAC_SHA384</ChecksumType>
+    <ChecksumSalt>5A17</ChecksumSalt>
+  </PillarChecksumSpec>
   <FileIDs>
     <FileID>MyDataID1</FileID>
   </FileIDs>

--- a/message-xml-xsd/src/main/resources/examples/messages/IdentifyPillarsForGetFileInfosResponse.xml
+++ b/message-xml-xsd/src/main/resources/examples/messages/IdentifyPillarsForGetFileInfosResponse.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Bitmagasin protokol
+
+  $Id$
+  $HeadURL$
+  %%
+  Copyright (C) 2010 The State and University Library, The Royal Library and The State Archives, Denmark
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 2.1 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+
+  You should have received a copy of the GNU General Lesser Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  #L%
+  -->
+
+<bro:IdentifyPillarsForGetFileInfosResponse
+        version="31" minVersion="31" xmlns:bro='http://bitrepository.org/BitRepositoryMessages.xsd'
+        xmlns="http://bitrepository.org/BitRepositoryElements.xsd">
+  <CorrelationID>12345</CorrelationID>
+  <CollectionID>MySla</CollectionID>
+  <Destination>topic://collectionTopic</Destination>
+  <ReplyTo>topic://clientTopic</ReplyTo>
+  <From>MyPillar</From>
+  <ResponseInfo>
+    <ResponseCode>IDENTIFICATION_POSITIVE</ResponseCode>
+    <ResponseText>Ready to deliver fileIDS.</ResponseText>
+  </ResponseInfo>
+  <PillarID>MyPillar</PillarID>
+  <FileIDs>
+    <FileID>MyDataID1</FileID>
+  </FileIDs>
+  <TimeToDeliver>
+    <TimeMeasureUnit>MILLISECONDS</TimeMeasureUnit>
+    <TimeMeasureValue>1000</TimeMeasureValue>
+  </TimeToDeliver>
+</bro:IdentifyPillarsForGetFileInfosResponse>

--- a/message-xml-xsd/src/main/resources/xsd/BitRepositoryData.xsd
+++ b/message-xml-xsd/src/main/resources/xsd/BitRepositoryData.xsd
@@ -108,6 +108,38 @@
   </xs:element>
 
   <!-- ***************************** -->
+  <!-- * Results for GetFileInfos  * -->
+  <!-- ***************************** -->
+
+  <xs:element name="GetFileInfosResults">
+    <xs:annotation><xs:documentation xml:lang="en">
+      Data format for delivery of checksums as result of GetFileInfos
+    </xs:documentation></xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="bre:CollectionID" >
+          <xs:annotation><xs:documentation xml:lang="en">
+            A unique identifier for bit repository collection which data belongs to.
+          </xs:documentation></xs:annotation>
+        </xs:element>
+
+        <xs:element ref="bre:PillarID" minOccurs="0" maxOccurs="1" >
+          <xs:annotation><xs:documentation xml:lang="en">
+            Identifier of pillar, that created the result
+          </xs:documentation></xs:annotation>
+        </xs:element>
+
+        <xs:element ref="bre:FileInfosDataItem" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation><xs:documentation xml:lang="en">
+            List of data for file infos
+          </xs:documentation></xs:annotation>
+        </xs:element>
+      </xs:sequence>
+      <xs:attributeGroup ref="bre:VersionAttributes"/>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- ***************************** -->
   <!-- * Results for GetFileIDs    * -->
   <!-- ***************************** -->
 

--- a/message-xml-xsd/src/main/resources/xsd/BitRepositoryElements.xsd
+++ b/message-xml-xsd/src/main/resources/xsd/BitRepositoryElements.xsd
@@ -422,6 +422,68 @@
     </xs:complexType>
   </xs:element>
 
+  <xs:element name="FileInfosData">
+    <xs:annotation><xs:documentation xml:lang="en">
+      Includes relevant information on data file Infos in a result
+    </xs:documentation></xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+
+        <xs:element name="FileInfosDataItems" >
+          <xs:annotation><xs:documentation xml:lang="en" >
+            List of data on data identifiers in result
+          </xs:documentation></xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element ref="FileInfosDataItem" minOccurs="0" maxOccurs="unbounded" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="FileInfosDataItem">
+    <xs:annotation><xs:documentation xml:lang="en">
+      Includes relevant information on a data ID in a result
+    </xs:documentation></xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="FileID" type="FileID_TYPE">
+          <xs:annotation><xs:documentation xml:lang="en">
+            Identifier of data
+          </xs:documentation></xs:annotation>
+        </xs:element>
+
+        <xs:element ref="FileSize" minOccurs="0" maxOccurs="1">
+          <xs:annotation><xs:documentation xml:lang="en">
+            The filesize in bytes.
+          </xs:documentation></xs:annotation>
+        </xs:element>
+
+        <xs:element name="LastModificationTime" type="SystemDateTime_TYPE" minOccurs="0" maxOccurs="1">
+          <xs:annotation><xs:documentation xml:lang="en">
+            The last modify timestamp of the file, or the latest time which the pillar had the whole file (especially
+            for off-line media).
+          </xs:documentation></xs:annotation>
+        </xs:element>
+
+        <xs:element name="ChecksumValue" type="ChecksumValue_TYPE" minOccurs="0" maxOccurs="1">
+          <xs:annotation><xs:documentation xml:lang="en">
+            The value of the checksum
+          </xs:documentation></xs:annotation>
+        </xs:element>
+
+        <xs:element name="CalculationTimestamp" type="SystemDateTime_TYPE" minOccurs="0" maxOccurs="1">
+          <xs:annotation><xs:documentation xml:lang="en">
+            The time when the checksum was last calculated (especially for ordinary checksums on off-line medias,
+            there can be long intervals between calculations, - in such cases this information is crucial for alarming)
+          </xs:documentation></xs:annotation>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
   <xs:element name="FileIDsParameterData">
     <xs:annotation>
       <xs:documentation xml:lang="en">
@@ -662,6 +724,27 @@
               List of data for file ids in result, if given in this message instead of via data transfer
             </xs:documentation>
           </xs:annotation>
+        </xs:element>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="ResultingFileInfos">
+    <xs:annotation><xs:documentation xml:lang="en">
+      results for GetFileInfos operaiton which is either given via specified address or directly
+    </xs:documentation></xs:annotation>
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="ResultAddress" minOccurs="0" maxOccurs="1" >
+          <xs:annotation><xs:documentation xml:lang="en">
+            Address (e.g. in form of an URL) for where result data has been delivered (if completed)
+          </xs:documentation></xs:annotation>
+        </xs:element>
+
+        <xs:element ref="FileInfosData">
+          <xs:annotation><xs:documentation xml:lang="en">
+            List of data for file ids in result, if given in this message instead of via data transfer
+          </xs:documentation></xs:annotation>
         </xs:element>
       </xs:choice>
     </xs:complexType>
@@ -1281,8 +1364,13 @@
   <xs:element name="MaxSequenceNumber" type="xs:positiveInteger"/>
   <xs:element name="MinTimestamp" type="SystemDateTime_TYPE"/>
   <xs:element name="MaxTimestamp" type="SystemDateTime_TYPE"/>
-  <xs:element name="MaxNumberOfResults" type="xs:positiveInteger"/>
-  <xs:element name="PartialResult" type="xs:boolean"/>
+  <xs:element name="MinChecksumTimestamp" type="SystemDateTime_TYPE" />
+  <xs:element name="MaxChecksumTimestamp" type="SystemDateTime_TYPE" />
+  <xs:element name="MinFileTimestamp" type="SystemDateTime_TYPE" />
+  <xs:element name="MaxFileTimestamp" type="SystemDateTime_TYPE" />
+  <xs:element name="MaxNumberOfResults" type="xs:positiveInteger" />
+  <xs:element name="PartialResult" type="xs:boolean" />
+  <xs:element name="GetFileSize" type="xs:boolean" />
 
   <xs:complexType name="TimeMeasure_TYPE">
     <xs:annotation>

--- a/message-xml-xsd/src/main/resources/xsd/BitRepositoryElements.xsd
+++ b/message-xml-xsd/src/main/resources/xsd/BitRepositoryElements.xsd
@@ -422,28 +422,7 @@
     </xs:complexType>
   </xs:element>
 
-  <xs:element name="FileInfosData">
-    <xs:annotation><xs:documentation xml:lang="en">
-      Includes relevant information on data file Infos in a result
-    </xs:documentation></xs:annotation>
-    <xs:complexType>
-      <xs:sequence>
-
-        <xs:element name="FileInfosDataItems" >
-          <xs:annotation><xs:documentation xml:lang="en" >
-            List of data on data identifiers in result
-          </xs:documentation></xs:annotation>
-          <xs:complexType>
-            <xs:sequence>
-              <xs:element ref="FileInfosDataItem" minOccurs="0" maxOccurs="unbounded" />
-            </xs:sequence>
-          </xs:complexType>
-        </xs:element>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
-
-  <xs:element name="FileInfosDataItem">
+   <xs:element name="FileInfosDataItem">
     <xs:annotation><xs:documentation xml:lang="en">
       Includes relevant information on a data ID in a result
     </xs:documentation></xs:annotation>
@@ -594,9 +573,8 @@
         <xs:element name="ResponseText" type="xs:string" minOccurs="0">
           <xs:annotation>
             <xs:documentation xml:lang="en">
-              The optional ReponseText can be used to include additional information in addition to the information
-              found in the
-              other elements. This will typically be relevant to describe details in problem situations.
+              The optional ResponseText can be used to include additional information in addition to the information
+              found in the other elements. This will typically be relevant to describe details in problem situations.
             </xs:documentation>
           </xs:annotation>
         </xs:element>
@@ -624,7 +602,7 @@
         <xs:element name="StatusText" type="xs:string">
           <xs:annotation>
             <xs:documentation xml:lang="en">
-              ReponseText is a textual description for logging, in a human readable form.
+              ResponseText is a textual description for logging, in a human readable form.
             </xs:documentation>
           </xs:annotation>
         </xs:element>
@@ -741,7 +719,7 @@
           </xs:documentation></xs:annotation>
         </xs:element>
 
-        <xs:element ref="FileInfosData">
+        <xs:element ref="FileInfosDataItem" minOccurs="0" maxOccurs="unbounded">
           <xs:annotation><xs:documentation xml:lang="en">
             List of data for file ids in result, if given in this message instead of via data transfer
           </xs:documentation></xs:annotation>

--- a/message-xml-xsd/src/main/resources/xsd/BitRepositoryMessages.xsd
+++ b/message-xml-xsd/src/main/resources/xsd/BitRepositoryMessages.xsd
@@ -1839,6 +1839,12 @@
               </xs:documentation></xs:annotation>
             </xs:element>
 
+            <xs:element ref="bre:ChecksumRequestForExistingFile" minOccurs="0" maxOccurs="1">
+              <xs:annotation><xs:documentation xml:lang="en">
+                Checksums type and possible salt requested
+              </xs:documentation></xs:annotation>
+            </xs:element>
+
             <xs:element ref="bre:ResultAddress" minOccurs="0" maxOccurs="1" >
               <xs:annotation><xs:documentation xml:lang="en">
                 Address (e.g. in form of an URL) for where data (file IDs) will be delivered

--- a/message-xml-xsd/src/main/resources/xsd/BitRepositoryMessages.xsd
+++ b/message-xml-xsd/src/main/resources/xsd/BitRepositoryMessages.xsd
@@ -1712,6 +1712,19 @@
               </xs:documentation></xs:annotation>
             </xs:element>
 
+            <xs:element ref="bre:ChecksumRequestForExistingFile" minOccurs="0" maxOccurs="1">
+              <xs:annotation><xs:documentation xml:lang="en">
+                Checksums type and possible salt requested
+              </xs:documentation></xs:annotation>
+            </xs:element>
+
+            <xs:element ref="bre:PillarChecksumSpec" minOccurs="0" maxOccurs="1" >
+              <xs:annotation><xs:documentation xml:lang="en">
+                Checksums type in case it is a checksum pillar replying,
+                only used for extra checks
+              </xs:documentation></xs:annotation>
+            </xs:element>
+
             <xs:element ref="bre:FileIDs" minOccurs="0" maxOccurs="1" >
               <xs:annotation><xs:documentation xml:lang="en" >
                 FileIDs uniquely identifies the files in given bit repository collection which the file ids are requested for

--- a/message-xml-xsd/src/main/resources/xsd/BitRepositoryMessages.xsd
+++ b/message-xml-xsd/src/main/resources/xsd/BitRepositoryMessages.xsd
@@ -1684,6 +1684,14 @@
                 Given in order to be able to give possible estimate of time to deliver
               </xs:documentation></xs:annotation>
             </xs:element>
+
+            <xs:element ref="bre:ChecksumRequestForExistingFile" minOccurs="0" maxOccurs="1">
+              <xs:annotation><xs:documentation xml:lang="en">
+                Optional checksums type and possible salt parameter requested
+                (only pillars that can deliver this kind of checksum should reply).
+                If not present pillars should use the default checksumtype specified in RepositorySettings.
+              </xs:documentation></xs:annotation>
+            </xs:element>
           </xs:sequence>
         </xs:extension>
       </xs:complexContent>

--- a/message-xml-xsd/src/main/resources/xsd/BitRepositoryMessages.xsd
+++ b/message-xml-xsd/src/main/resources/xsd/BitRepositoryMessages.xsd
@@ -1668,6 +1668,217 @@
     </xs:complexType>
   </xs:element>
 
+  <!-- Implements the GetFileInfos functionality as described here: https://sbforge.org/display/BITMAG/Get+FileInfos (TODO: make page) -->
+
+  <xs:element name="IdentifyPillarsForGetFileInfosRequest">
+    <xs:complexType>
+      <xs:annotation><xs:documentation xml:lang="en">
+        REQUEST in IdentifyPillarsForGetFileInfos primitive
+      </xs:documentation></xs:annotation>
+      <xs:complexContent>
+        <xs:extension base="MessageRequest">
+          <xs:sequence>
+            <xs:element ref="bre:FileIDs" minOccurs="0" maxOccurs="1" >
+              <xs:annotation><xs:documentation xml:lang="en">
+                FileIDs uniquely identifies the files in given bit repository collection which the file ids are requested for
+                Given in order to be able to give possible estimate of time to deliver
+              </xs:documentation></xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="IdentifyPillarsForGetFileInfosResponse">
+    <xs:complexType>
+      <xs:annotation><xs:documentation xml:lang="en">
+        RESPONSE in IdentifyPillarsForGetFileInfos primitive
+      </xs:documentation></xs:annotation>
+      <xs:complexContent>
+        <xs:extension base="MessageResponse">
+          <xs:sequence>
+            <xs:element ref="bre:PillarID" >
+              <xs:annotation><xs:documentation xml:lang="en">
+                Unique identifier for pillar replying
+              </xs:documentation></xs:annotation>
+            </xs:element>
+
+            <xs:element ref="bre:FileIDs" minOccurs="0" maxOccurs="1" >
+              <xs:annotation><xs:documentation xml:lang="en" >
+                FileIDs uniquely identifies the files in given bit repository collection which the file ids are requested for
+                only to repeat parameter from request.
+              </xs:documentation></xs:annotation>
+            </xs:element>
+
+            <xs:element ref="bre:TimeToDeliver" minOccurs="0" maxOccurs="1" >
+              <xs:annotation><xs:documentation xml:lang="en">
+                Estimated time before delivery of data (fileInfos) requested.
+                That means the time from receiving a GetFileInfosRequest message to the time
+                when data has been collected and returned in a GetFileInfosFinalResponse message.
+              </xs:documentation></xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="GetFileInfosRequest">
+    <xs:complexType>
+      <xs:annotation><xs:documentation xml:lang="en">
+        REQUEST in GetFileInfos primitive
+      </xs:documentation></xs:annotation>
+      <xs:complexContent>
+        <xs:extension base="MessageRequest">
+          <xs:sequence>
+            <xs:element ref="bre:PillarID" minOccurs="0" maxOccurs="1" >
+              <xs:annotation><xs:documentation xml:lang="en">
+                Identifier of receiving pillar, which can be used for possible checks
+                (IdentifyPillarsForGetFileInfosResponse.ReplyTo should ensure that right pillar is reached)
+              </xs:documentation></xs:annotation>
+            </xs:element>
+
+            <xs:element ref="bre:FileIDs" >
+              <xs:annotation><xs:documentation xml:lang="en">
+                FileIDs uniquely identifies the files in given bit repository collection which the file ids are requested for
+              </xs:documentation></xs:annotation>
+            </xs:element>
+            <xs:element ref="bre:ChecksumRequestForExistingFile" minOccurs="0" maxOccurs="1">
+              <xs:annotation><xs:documentation xml:lang="en">
+                Checksums type and possible salt requested.
+                If this element is missing, then no checksum is requested
+              </xs:documentation></xs:annotation>
+            </xs:element>
+            <xs:element ref="bre:GetFileSize" minOccurs="0" maxOccurs="1">
+              <xs:annotation><xs:documentation xml:lang="en">
+                Whether or not to require the size of the file as part of the response.
+                Defaults to true.
+              </xs:documentation></xs:annotation>
+            </xs:element>
+
+            <xs:element ref="bre:MinFileTimestamp"  minOccurs="0" >
+              <xs:annotation><xs:documentation xml:lang="en">
+                Only fileInfos for files added/updated later or at the same time as the minFileTimestamp should be returned.
+              </xs:documentation></xs:annotation>
+            </xs:element>
+            <xs:element ref="bre:MaxFileTimestamp"  minOccurs="0" >
+              <xs:annotation><xs:documentation xml:lang="en">
+                Only fileInfos for files added/updated before or at the same time as the maxFileTimestamp should be returned.
+              </xs:documentation></xs:annotation>
+            </xs:element>
+            <xs:element ref="bre:MinChecksumTimestamp"  minOccurs="0" >
+              <xs:annotation><xs:documentation xml:lang="en">
+                Only fileInfos for checksums younger or at the same time as the minChecksumTimestamp should be returned.
+              </xs:documentation></xs:annotation>
+            </xs:element>
+            <xs:element ref="bre:MaxChecksumTimestamp"  minOccurs="0" >
+              <xs:annotation><xs:documentation xml:lang="en">
+                Only fileInfos for checksums with checksums older or at the same time as the maxCheckusumTimestamp should be returned.
+              </xs:documentation></xs:annotation>
+            </xs:element>
+            <xs:element ref="bre:MaxNumberOfResults"  minOccurs="0" >
+              <xs:annotation><xs:documentation xml:lang="en">
+                Request the contributor to only return 'up-to' MaxNumberOfResults of fileInfo results. This can be
+                used to break a fileInfo retrieval into small result sets (paging).
+              </xs:documentation></xs:annotation>
+            </xs:element>
+
+            <xs:element ref="bre:ResultAddress" minOccurs="0" maxOccurs="1" >
+              <xs:annotation><xs:documentation xml:lang="en">
+                Address (e.g. in form of an URL) for where data (fileInfos) must be delivered via file exchange
+                In cases where the address is not given, the result will be given in the GetFileIdsFinalResponse message
+              </xs:documentation></xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="GetFileInfosProgressResponse">
+    <xs:complexType>
+      <xs:annotation><xs:documentation xml:lang="en">
+        PROGRESS RESPONSE in GetFileInfos primitive
+      </xs:documentation></xs:annotation>
+      <xs:complexContent>
+        <xs:extension base="MessageResponse">
+          <xs:sequence>
+            <xs:element ref="bre:PillarID" minOccurs="0" maxOccurs="1" >
+              <xs:annotation><xs:documentation xml:lang="en">
+                Identifier of responding pillar, which can be used for possible checks
+                (otherwise it is known via CorrelationID and ReplyTo)
+              </xs:documentation></xs:annotation>
+            </xs:element>
+
+            <xs:element ref="bre:FileIDs" minOccurs="0" maxOccurs="1" >
+              <xs:annotation><xs:documentation xml:lang="en">
+                FileIDs uniquely identifies the files in given bit repository collection which the file ids are requested for
+                (otherwise it is known via CorrelationID)
+              </xs:documentation></xs:annotation>
+            </xs:element>
+
+            <xs:element ref="bre:ResultAddress" minOccurs="0" maxOccurs="1" >
+              <xs:annotation><xs:documentation xml:lang="en">
+                Address (e.g. in form of an URL) for where data (file IDs) will be delivered
+              </xs:documentation></xs:annotation>
+            </xs:element>
+
+          </xs:sequence>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="GetFileInfosFinalResponse">
+    <xs:complexType>
+      <xs:annotation><xs:documentation xml:lang="en">
+        FINAL RESPONSE in GetFileInfos primitive
+      </xs:documentation></xs:annotation>
+      <xs:complexContent>
+        <xs:extension base="MessageResponse">
+          <xs:sequence>
+            <xs:element ref="bre:PillarID" minOccurs="0" maxOccurs="1" >
+              <xs:annotation><xs:documentation xml:lang="en">
+                Identifier of responding pillar, which can be used for possible checks
+                (otherwise it is known via CorrelationID and ReplyTo)
+              </xs:documentation></xs:annotation>
+            </xs:element>
+
+            <xs:element ref="bre:FileIDs" minOccurs="0" maxOccurs="1" >
+              <xs:annotation><xs:documentation xml:lang="en">
+                FileIDs uniquely identifies the files in given collection which the file ids are requested for. If not present
+                it means all the requested files are present on the pillar.
+              </xs:documentation></xs:annotation>
+            </xs:element>
+
+            <xs:element ref="bre:ChecksumRequestForExistingFile" minOccurs="0" maxOccurs="1" >
+              <xs:annotation><xs:documentation xml:lang="en">
+                Checksums type and possible salt requested
+                (Also in result, and traceable via CorrelationID)
+              </xs:documentation></xs:annotation>
+            </xs:element>
+
+            <xs:element ref="bre:ResultingFileInfos" minOccurs="0" maxOccurs="1">
+              <xs:annotation><xs:documentation xml:lang="en">
+                Result with file infos.
+              </xs:documentation></xs:annotation>
+            </xs:element>
+
+            <xs:element ref="bre:PartialResult" minOccurs="0" maxOccurs="1" >
+              <xs:annotation><xs:documentation xml:lang="en">
+                Indicates whether the list of result were limited for some reason, either a MaxLimit in the request
+                or a limit defined in the contributor.  If all results have been returned
+                this should be false or undefined.
+              </xs:documentation></xs:annotation>
+            </xs:element>
+
+          </xs:sequence>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
 
   <!-- Implements the GetStatus functionality as described here: https://sbforge.org/display/BITMAG/Get+Status -->
 


### PR DESCRIPTION
This is a old feature request that allows for the operation `GetFileInfos`, which contains the combined data of `GetFileIDs` and `GetChecksums` and was intended to eventually replace the two. 

Merging this has been post-poned indefinitely as the operation itself currently provides little benefit compared to the cost of having the using implementations support it.

The original branch `getfileinfo` has been left for reference, but `updated-getfileinfos` should contain all the relevant merged changes, so it should be no issue to remove the old one and use this current one.